### PR TITLE
Check if com.squareup.okhttp.CertificatePinner class exists before hooking

### DIFF
--- a/app/src/main/java/just/trust/me/Main.java
+++ b/app/src/main/java/just/trust/me/Main.java
@@ -214,12 +214,18 @@ public class Main implements IXposedHookLoadPackage {
       throws SSLPeerUnverifiedException{}*/
       /* Either returns true or a exception so blanket return true */
       /* Tested against version 2.5 */
-        findAndHookMethod("com.squareup.okhttp.CertificatePinner", lpparam.classLoader, "check", String.class, List.class, new XC_MethodReplacement() {
-            @Override
-            protected Object replaceHookedMethod(MethodHookParam methodHookParam) throws Throwable {
-                return true;
-            }
-        });
+
+        try {
+            Class.forName("com.squareup.okhttp.CertificatePinner");
+            findAndHookMethod("com.squareup.okhttp.CertificatePinner", lpparam.classLoader, "check", String.class, List.class, new XC_MethodReplacement() {
+                @Override
+                protected Object replaceHookedMethod(MethodHookParam methodHookParam) throws Throwable {
+                    return true;
+                }
+            });
+        } catch(ClassNotFoundException e) {
+            // pass
+        }
 
         /* Only for newer devices should we try to hook TrustManagerImpl */
         if (hasTrustManagerImpl()) {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.5.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
[findMethodExact](https://github.com/rovo89/XposedBridge/blob/2a962c0d3782de974492bb46111578c18596e717/src/de/robv/android/xposed/XposedHelpers.java#L181) will throw an exception when the class or method is not found. Since okhttp is a thirdparty library, we should check it before hooking, othewise the rest code of handleLoadPackage will not be executed.