### PR TITLE
add checkServerTrusted(X509Certificate[], String, String, String) method

### DIFF
--- a/app/src/main/java/just/trust/me/Main.java
+++ b/app/src/main/java/just/trust/me/Main.java
@@ -534,6 +534,11 @@ public class Main implements IXposedHookLoadPackage {
         public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
         }
 
+	public List<X509Certificate> checkServerTrusted(X509Certificate[] chain, String authType, String host) throws CertificateException {
+		ArrayList<X509Certificate> list = new ArrayList<X509Certificate>();
+		return list;
+	}
+
         @Override
         public X509Certificate[] getAcceptedIssuers() {
             return new X509Certificate[0];


### PR DESCRIPTION
Hi
I have problem with genymotion 3.0 android 7.1.0
Trying to use JustTristMe on webview.
I see that hooking was successed.
`JustTrustMe  D  Hooking DefaultHTTPClient for: com.google.android.webview`
`                         D  Hooking com.android.org.conscrypt.TrustManagerImpl for: com.google.android.webview`
But then I use https-link it makes error:
`X509Util  E  Error creating trust manager (just.trust.me.Main$ImSureItsLegitTrustManager): java.lang.IllegalArgumentException: Required method checkServerTrusted(X509Certificate[], String, String, String) missing`
`                         E  Could not find suitable trust manager`
Patched by adding this method.