### PR TITLE
chore: comment proxy config

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Mon Jun 26 14:34:35 CST 2017
-systemProp.http.proxyHost=127.0.0.1
-systemProp.http.proxyPort=1080
+#systemProp.http.proxyHost=127.0.0.1
+#systemProp.http.proxyPort=1080


### PR DESCRIPTION
This is an infrequently used configuration introduced from commit ad5c3dd, which can lead to unknowingly troubleshooting non-existent network problems all the time.